### PR TITLE
cmd_vel improve

### DIFF
--- a/spot_driver/config/spot_ros.yaml
+++ b/spot_driver/config/spot_ros.yaml
@@ -10,3 +10,4 @@ rates:
 auto_claim: False
 auto_power_on: False
 auto_stand: False
+velocity_cmd_duration: 0.5

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -531,7 +531,7 @@ class SpotROS():
     def cmdVelCallback(self, data):
         """Callback for cmd_vel command"""
         self.velocity_cmd_received_timestamp = rospy.Time.now()
-        self.spot_wrapper.velocity_cmd(data.linear.x, data.linear.y, data.angular.z)
+        self.spot_wrapper.velocity_cmd(data.linear.x, data.linear.y, data.angular.z, cmd_duration=self.velocity_cmd_duration)
         self.velocity_cmd_publish_zero = False
 
     def bodyPoseCallback(self, data):
@@ -694,6 +694,7 @@ class SpotROS():
         self.velocity_cmd_received_timeout = rospy.get_param('~velocity_cmd_received_timeout', 1.0)
         self.velocity_cmd_publish_zero = False
         self.velocity_cmd_received_timestamp = rospy.Time.now()
+        self.velocity_cmd_duration = rospy.get_param('~velocity_cmd_duration', 0.125)
 
         self.camera_static_transform_broadcaster = tf2_ros.StaticTransformBroadcaster()
         # Static transform broadcaster is super simple and just a latched publisher. Every time we add a new static


### PR DESCRIPTION
- spot_driver/src/spot_driver/spot_ros.py: add velocity_cmd_duration (Time-to-live for the command in seconds). Default time is 0.125, but core-io is too heavy and set to 0.5
- spot_driver/src/spot_driver/spot_ros.py: publish zero cmd velocity if we do not see cmd_vel for cmd_received_timeout sec
