### PR TITLE
[spot_driver] add vision_msgs depend

### DIFF
--- a/spot_driver/package.xml
+++ b/spot_driver/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>interactive_marker_twist_server</exec_depend>
   <exec_depend>teleop_twist_joy</exec_depend>
   <exec_depend>velodyne_pointcloud</exec_depend>
+  <exec_depend>vision_msgs</exec_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml" />


### PR DESCRIPTION
The driver requires `vision_msgs` . See https://github.com/k-okada/spot_ros-arm/blob/d4bdb07347a8890b96fa45f538000a93645ce21e/spot_driver/src/spot_driver/arm/arm_wrapper.py#L12