### PR TITLE
reenable initial_localization_waypoint

### DIFF
--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -833,9 +833,9 @@ class SpotWrapper():
             self._upload_graph_and_snapshots(upload_filepath)
         if initial_localization_fiducial:
             self._set_initial_localization_fiducial()
-        #if initial_localization_waypoint:
-        #    self._set_initial_localization_waypoint([initial_localization_waypoint])
-        #self._list_graph_waypoint_and_edge_ids()
+        if initial_localization_waypoint:
+           self._set_initial_localization_waypoint([initial_localization_waypoint])
+        self._list_graph_waypoint_and_edge_ids()
         self._get_localization_state()
         if len(navigate_to) > 0:
             rospy.loginfo("Told to navigate to: [{}]".format(navigate_to))
@@ -872,7 +872,7 @@ class SpotWrapper():
             self._logger.error("No waypoint specified to initialize to.")
             return
         destination_waypoint = graph_nav_util.find_unique_waypoint_id(
-            args[0][0], self._current_graph, self._current_annotation_name_to_wp_id, self._logger)
+            args[0][0], self._current_graph, self._current_annotation_name_to_wp_id)
         if not destination_waypoint:
             # Failed to find the unique waypoint id.
             return


### PR DESCRIPTION
I don't know why but `initial_localization_waypoint` is commented out, and the function related to it has syntax error. This PR fixes it.

The patch
- https://github.com/k-okada/spot_ros-arm/pull/6

has more features, but I only want to keep backward compatibility with this PR.