### PR TITLE
[spot_driver][graph_nav] impl cancel goal in navigate_to action

### DIFF
--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -568,22 +568,38 @@ class SpotROS():
                 self.navigate_as.publish_feedback(NavigateToFeedback(localization_state.localization.waypoint_id))
             rospy.Rate(10).sleep()
 
+    def handle_navigate_to_cancel(self):
+        """Thread function to cancel the current navigate_to"""
+        while not rospy.is_shutdown() and self.run_navigate_to:
+            if self.navigate_as.is_preempt_requested():
+                rospy.loginfo("Cancelling graph nav navigate_to...")
+                self.spot_wrapper.cancel_navigate_to()
+                self._navigate_to_canceled = True
+                break
+            rospy.Rate(10).sleep()
+
     def handle_navigate_to(self, msg):
         """ROS service handler to run mission of the robot.  The robot will replay a mission"""
         # create thread to periodically publish feedback
-        feedback_thraed = threading.Thread(target = self.handle_navigate_to_feedback, args = ())
+        self._navigate_to_canceled = False
+        feedback_thread = threading.Thread(target = self.handle_navigate_to_feedback, args = ())
+        preempt_thread = threading.Thread(target = self.handle_navigate_to_cancel, args = ())
         self.run_navigate_to = True
-        feedback_thraed.start()
+        feedback_thread.start()
+        preempt_thread.start()
         # run navigate_to
         resp = self.spot_wrapper.navigate_to(upload_path = msg.upload_path,
                                              navigate_to = msg.navigate_to,
                                              initial_localization_fiducial = msg.initial_localization_fiducial,
                                              initial_localization_waypoint = msg.initial_localization_waypoint)
         self.run_navigate_to = False
-        feedback_thraed.join()
+        feedback_thread.join()
+        preempt_thread.join()
 
         # check status
-        if resp[0]:
+        if self._navigate_to_canceled:
+            self.navigate_as.set_preempted(NavigateToResult(False, "Cancelled"))
+        elif resp[0]:
             self.navigate_as.set_succeeded(NavigateToResult(resp[0], resp[1]))
         else:
             self.navigate_as.set_aborted(NavigateToResult(resp[0], resp[1]))

--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -365,6 +365,8 @@ class SpotWrapper():
             self._current_edge_snapshots = dict()  # maps id to edge snapshot
             self._current_annotation_name_to_wp_id = dict()
 
+            self._cancel_navigate_to = False
+
             # Async Tasks
             self._async_task_list = []
             self._robot_state_task = AsyncRobotState(self._robot_state_client,
@@ -1042,6 +1044,9 @@ class SpotWrapper():
 #            # The robot is not localized to the newly uploaded graph.
 #            self._logger.info("Upload complete! The robot is currently not localized to the map; please localize the robot using commands (2) or (3) before attempting a navigation command.")
 
+    def cancel_navigate_to(self):
+        self._cancel_navigate_to = True
+
     def _navigate_to(self, goal):
         """Navigate to a specific waypoint."""
         # Take the first argument as the destination waypoint.
@@ -1051,6 +1056,13 @@ class SpotWrapper():
         #    return
 
         self._lease = self._lease_wallet.get_lease()
+
+        if self._current_graph is None:
+            try:
+                self._list_graph_waypoint_and_edge_ids()
+            except Exception as e:
+                return False, "No graph loaded (upload graph first)"
+
         destination_waypoint = graph_nav_util.find_unique_waypoint_id(
             goal, self._current_graph, self._current_annotation_name_to_wp_id)
         if not destination_waypoint:
@@ -1066,9 +1078,10 @@ class SpotWrapper():
         self._lease_keepalive.shutdown()
 
         # Navigate to the destination waypoint.
+        self._cancel_navigate_to = False
         is_finished = False
         nav_to_cmd_id = -1
-        while not is_finished:
+        while (not is_finished) and (not self._cancel_navigate_to): # Exit navigate_to loop when cancel request is received
             # Issue the navigation command about twice a second such that it is easy to terminate the
             # navigation command (with estop or killing the program).
             nav_to_cmd_id = self._graph_nav_client.navigate_to(destination_waypoint, 1.0,


### PR DESCRIPTION
Implementing the cancel goal in navigate_to. The user can abort navigate_to with sending cancel_goal. It requires in failure detection and recovery demo.
